### PR TITLE
Add rails to vagrant with shell provisioner

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,5 +72,8 @@ Vagrant.configure(2) do |config|
      sudo apt-get install ruby2.2-dev -y
      sudo apt-get install -y git
      sudo apt-get install -y emacs
+     sudo apt-get install -y libxslt-dev libxml2-dev zlib1g-dev
+     sudo gem install nokogiri
+     sudo gem install rails --no-document
   SHELL
- end
+end


### PR DESCRIPTION
rails 4.2.2 and nokogiri 1.6.6.2 has installation error.
So we need to intall libxslt-dev libxml2-dev zlib1g-dev libraries.
I had written doc to following url
http://qiita.com/YutakakINJO/items/8a765ec280b75bc5e400
